### PR TITLE
카메라 전/후면 전환 기능 추가 & UI 변경 및 애니메이션 추가

### DIFF
--- a/toyCamera/toyCamera/Presentation/Camera/View/CameraViewController.swift
+++ b/toyCamera/toyCamera/Presentation/Camera/View/CameraViewController.swift
@@ -28,8 +28,11 @@ class CameraViewController: UIViewController {
     
     private var captureButton: UIButton = {
         let captureButton = UIButton()
-        captureButton.setImage(UIImage(named: "CaptureIcon"), for: .normal)
-        captureButton.backgroundColor = .white
+        captureButton.setImage(UIImage(systemName: "camera.aperture"), for: .normal)
+        captureButton.contentHorizontalAlignment = .fill
+        captureButton.contentVerticalAlignment = .fill
+        captureButton.tintColor = .white
+        captureButton.backgroundColor = .black
         captureButton.translatesAutoresizingMaskIntoConstraints = false
         return captureButton
     }()
@@ -52,7 +55,7 @@ class CameraViewController: UIViewController {
     override func loadView() {
         super.loadView()
         self.view = .init()
-        self.view.backgroundColor = .white
+        self.view.backgroundColor = .black
         self.view.addSubview(self.previewView)
         self.view.addSubview(self.blackShutterView)
         self.view.addSubview(self.captureButton)


### PR DESCRIPTION
- #2 
- 카메라 버튼 클릭시 preview 검은화면으로 셔터처리
- Base Color White -> Black 으로 변경
- 다양한 기종에 대응하도록 DiscoverySession Device 추가
  - 3개 카메라 -> TripleCamera
  - 2개 카메라 (11 이후) -> DuelWideCamera
  - 2개 카메라 (Xs 이전) -> DuelCamera
  - 1개 카메라 -> WideAngleCamera
  - 전면 카메라 -> TureDepthCamera